### PR TITLE
feat(ambito): agregar modelo y modal para la gestión de ámbitos en el…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import RolesPage from "@/pages/rol-page/RolesPage";
 import UsuariosPage from "@/pages/usuarios-page/UsuariosPage";
 import IngresoDocumentosPage from '@/pages/documentos-page/IngresoDocumentosPage';
 import ListaDocumentosPage from './pages/documentos-page/ListaDocumentosPage';
+import AmbitoPage from './pages/ambito-page/AmbitoPage';
 import { Toaster } from './components/ui/toaster';  // Asegúrate de importar el componente Toaster
 
 function App() {
@@ -31,6 +32,7 @@ function App() {
                         <Route path="areas/lista" element={<AreasPage />} />
                         <Route path="mesa-partes/ingreso" element={<IngresoDocumentosPage />} />
                         <Route path="documentos/lista" element={<ListaDocumentosPage />} />
+                        <Route path="documentos/ambitos/lista" element={<AmbitoPage />} />
 
                         {/* Redirecciones */}
 
@@ -40,6 +42,7 @@ function App() {
                         <Route path="documentos" element={<Navigate to="/documentos/lista" replace />} />
                         <Route path="mesa-partes" element={<Navigate to="/mesa-partes/ingreso" replace />} />
                         <Route path="usuarios/roles" element={<Navigate to="/usuarios/roles/lista" replace />} />
+                        <Route path="documentos/ambitos" element={<Navigate to="/documentos/ambitos/lista" replace />} />
 
                         {/* Manejo de rutas no encontradas */}
                         <Route path="*" element={<div className="p-4">Página no encontrada</div>} />

--- a/src/components/modal/ambito-modal/AmbitoModal.tsx
+++ b/src/components/modal/ambito-modal/AmbitoModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Edit, Save, XCircle, Plus } from "lucide-react";
+import { Ambito } from "@/model/ambito";
+
+const formSchema = z.object({
+  nombreAmbito: z
+    .string()
+    .min(2, {
+      message: "El nombre del ámbito debe tener al menos 2 caracteres",
+    })
+    .regex(/^[A-Za-zÀ-ÿ\s]+$/, {
+      message: "El nombre del ámbito no debe contener números",
+    }),
+});
+
+interface AmbitoModalProps {
+  isOpen: boolean;
+  ambito?: Ambito;
+  onClose: () => void;
+  onSubmit: (data: Ambito) => Promise<void>;
+}
+
+export function AmbitoModal({
+  isOpen,
+  ambito,
+  onClose,
+  onSubmit,
+}: AmbitoModalProps) {
+  const isEditing = ambito?.id && ambito.id > 0;
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      nombreAmbito: "",
+    },
+  });
+
+  useEffect(() => {
+    if (ambito) {
+      form.reset({
+        nombreAmbito: ambito.nombreAmbito,
+      });
+    } else {
+      form.reset({
+        nombreAmbito: "",
+      });
+    }
+  }, [ambito, form]);
+
+  const handleSubmit = async (values: z.infer<typeof formSchema>) => {
+    const ambitoData: Ambito = {
+      id: ambito?.id || 0,
+      nombreAmbito: values.nombreAmbito,
+    };
+    await onSubmit(ambitoData);
+    handleClose();
+  };
+
+  const handleClose = () => {
+    form.reset();
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[600px] p-0 bg-white max-h-[90vh] overflow-hidden flex flex-col">
+        <DialogHeader className="bg-gradient-to-l from-[#028a3b] via-[#014920] to-black text-white p-6 rounded-t-lg shadow-md">
+          <DialogTitle className="text-2xl font-bold flex items-center">
+            {isEditing ? (
+              <Edit className="mr-2 h-6 w-6" />
+            ) : (
+              <Plus className="mr-2 h-6 w-6" />
+            )}
+            {isEditing ? "Editar Ámbito" : "Registrar Ámbito"}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-emerald-100">
+            {isEditing
+              ? "Modifica los datos del ámbito según sea necesario."
+              : "Complete el formulario para registrar un nuevo ámbito."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="overflow-y-auto flex-grow scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-gray-100">
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="p-6 space-y-6"
+            >
+              <FormField
+                control={form.control}
+                name="nombreAmbito"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nombre del Ámbito</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Ingrese el nombre del ámbito"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter className="pt-6 flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
+                <Button
+                  type="button"
+                  onClick={handleClose}
+                  className="w-full sm:w-auto bg-[#d82f2f] text-white hover:bg-[#991f1f] flex items-center justify-center"
+                >
+                  <XCircle className="w-5 h-5 mr-2" />
+                  Cancelar
+                </Button>
+                <Button
+                  type="submit"
+                  className="w-full sm:w-auto bg-emerald-600 text-white hover:bg-emerald-700 flex items-center justify-center"
+                >
+                  <Save className="w-5 h-5 mr-2" />
+                  {isEditing ? "Guardar Cambios" : "Registrar"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/model/ambito.ts
+++ b/src/model/ambito.ts
@@ -1,0 +1,4 @@
+export interface Ambito{
+    id?: number;
+    nombreAmbito: string;
+}

--- a/src/model/ambitoPaginatedResponse.ts
+++ b/src/model/ambitoPaginatedResponse.ts
@@ -1,0 +1,4 @@
+import { PaginatedResponse } from "./pagination";
+import { Ambito } from "./ambito";
+
+export type AmbitoPaginatedResponse = PaginatedResponse<Ambito>;

--- a/src/pages/ambito-page/AmbitoPage.tsx
+++ b/src/pages/ambito-page/AmbitoPage.tsx
@@ -1,0 +1,299 @@
+import { useState, useMemo} from "react";
+import { Button } from "@/components/ui/button";
+import { Plus, Search, Pencil, Trash2 } from "lucide-react";
+import { Ambito } from "@/model/ambito";
+import { AmbitoModal } from "@/components/modal/ambito-modal/AmbitoModal";
+import DeleteModal from "@/components/modal/alerts/delete-modal/DeleteModal";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHead,
+  TableRow,
+} from "@/components/ui/table";
+import { AnimatePresence, motion } from "framer-motion";
+import { Input } from "@/components/ui/input";
+import { Pagination } from "@/components/ui/pagination";
+import { AmbitoPaginatedResponse } from "@/model/ambitoPaginatedResponse";
+
+const ambitosData: Ambito[] = [
+  { id: 1, nombreAmbito: "Ámbito 1" },
+  { id: 2, nombreAmbito: "Ámbito 2" },
+  { id: 3, nombreAmbito: "Ámbito 3" },
+  { id: 4, nombreAmbito: "Ámbito 4" },
+  { id: 5, nombreAmbito: "Ámbito 5" },
+];
+
+const tableVariants = {
+  initial: { opacity: 0, scale: 0.95 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.95 },
+};
+
+const AmbitoPage: React.FC = () => {
+  const [ambitosState, setAmbitosState] = useState<AmbitoPaginatedResponse>({
+    data: ambitosData,
+    pagination: {
+      currentPage: 1,
+      pageSize: 4,
+      totalItems: ambitosData.length,
+      totalPages: Math.ceil(ambitosData.length / 4),
+    },
+  });
+  const [, setCurrentPage] = useState<number>(1);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+  const [selectedAmbito, setSelectedAmbito] = useState<Ambito | undefined>(
+    undefined
+  );
+  const [dataVersion, setDataVersion] = useState<number>(0);
+  const [searchTerm, setSearchTerm] = useState<string>("");
+
+  const totalPages = ambitosState.pagination.totalPages;
+
+  const filteredAmbitos = useMemo(() => {
+    return ambitosState.data.filter((ambito) =>
+      ambito.nombreAmbito.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [ambitosState.data, searchTerm]);
+
+  const currentAmbitos = useMemo(() => {
+    const startIndex =
+      (ambitosState.pagination.currentPage - 1) *
+      ambitosState.pagination.pageSize;
+    return filteredAmbitos.slice(
+      startIndex,
+      startIndex + ambitosState.pagination.pageSize
+    );
+  }, [ambitosState.pagination.currentPage, ambitosState.pagination.pageSize, filteredAmbitos]);
+
+  const handleEdit = (id?: number) => {
+    if (id !== undefined) {
+      const ambito = ambitosState.data.find((a) => a.id === id);
+      if (ambito) {
+        setSelectedAmbito(ambito);
+        setIsModalOpen(true);
+      }
+    }
+  };
+
+  const handleDeleteClick = (id?: number) => {
+    if (id !== undefined) {
+      const ambito = ambitosState.data.find((a) => a.id === id);
+      if (ambito) {
+        setSelectedAmbito(ambito);
+        setIsDeleteModalOpen(true);
+      }
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (selectedAmbito) {
+      const updatedData = ambitosState.data.filter(
+        (a) => a.id !== selectedAmbito.id
+      );
+      const totalItems = updatedData.length;
+      const totalPages = Math.ceil(totalItems / ambitosState.pagination.pageSize);
+      setAmbitosState({
+        data: updatedData,
+        pagination: {
+          ...ambitosState.pagination,
+          totalItems,
+          totalPages,
+          currentPage:
+            ambitosState.pagination.currentPage > totalPages
+              ? totalPages
+              : ambitosState.pagination.currentPage,
+        },
+      });
+      setIsDeleteModalOpen(false);
+      setSelectedAmbito(undefined);
+      setDataVersion((prev) => prev + 1);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setAmbitosState((prevState) => ({
+      ...prevState,
+      pagination: {
+        ...prevState.pagination,
+        currentPage: page,
+      },
+    }));
+    setCurrentPage(page);
+  };
+
+  const handleModalSubmit = async (data: Ambito) => {
+    if (data.id) {
+      // Actualizar ámbito existente
+      const updatedData = ambitosState.data.map((a) =>
+        a.id === data.id ? data : a
+      );
+      setAmbitosState((prevState) => ({
+        ...prevState,
+        data: updatedData,
+      }));
+    } else {
+      // Agregar nuevo ámbito
+      const newId =
+        ambitosState.data.length > 0
+          ? Math.max(...ambitosState.data.map((a) => a.id || 0)) + 1
+          : 1;
+      const newAmbito = { ...data, id: newId };
+      const updatedData = [...ambitosState.data, newAmbito];
+      const totalItems = updatedData.length;
+      const totalPages = Math.ceil(totalItems / ambitosState.pagination.pageSize);
+      setAmbitosState({
+        data: updatedData,
+        pagination: {
+          ...ambitosState.pagination,
+          totalItems,
+          totalPages,
+        },
+      });
+    }
+    setIsModalOpen(false);
+    setSelectedAmbito(undefined);
+    setDataVersion((prev) => prev + 1);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedAmbito(undefined);
+    setIsModalOpen(false);
+  };
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+    setAmbitosState((prevState) => ({
+      ...prevState,
+      pagination: {
+        ...prevState.pagination,
+        currentPage: 1,
+      },
+    }));
+    setCurrentPage(1);
+  };
+
+  return (
+    <div className="pt-0.5 pr-0.5 pb-1 pl-0.5 sm:pt-2 sm:pr-2 sm:pb-4 sm:pl-2 bg-transparent">
+      <div className="flex flex-col sm:flex-row justify-between items-center mb-4 sm:mb-8 mt-4 bg-transparent">
+        <h2 className="text-2xl font-bold text-gray-800 mb-2 sm:mb-0">
+          Ámbitos
+        </h2>
+        <Button
+          onClick={() => {
+            setSelectedAmbito(undefined);
+            setIsModalOpen(true);
+          }}
+          className="w-full sm:w-auto px-4 py-2 bg-[#03A64A] text-white rounded hover:bg-[#028a3b] transition-colors duration-200 flex items-center justify-center"
+        >
+          <Plus className="w-5 h-5 mr-2" />
+          Agregar Ámbito
+        </Button>
+      </div>
+
+      <div className="w-full overflow-hidden bg-white rounded-lg shadow-lg">
+        <div className="relative mb-4 p-4 border-b border-gray-200">
+          <Search className="absolute left-7 top-1/2 transform -translate-y-1/2 text-gray-400" />
+          <Input
+            type="text"
+            id="search"
+            name="search"
+            placeholder="Buscar ámbitos..."
+            className="pl-10 w-full border-gray-300 focus:border-[#03A64A] focus:ring focus:ring-[#03A64A] focus:ring-opacity-50 rounded-md shadow-sm"
+            aria-label="Buscar ámbitos"
+            value={searchTerm}
+            onChange={handleSearch}
+          />
+        </div>
+        <div className="overflow-x-auto">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={`${ambitosState.pagination.currentPage}-${dataVersion}-${searchTerm}`}
+              variants={tableVariants}
+              initial="initial"
+              animate="animate"
+              exit="exit"
+              transition={{ duration: 0.5 }}
+              className="w-full"
+            >
+              <Table className="min-w-full divide-y divide-gray-200">
+                <TableHeader>
+                  <TableRow className="bg-gray-50 border-b border-gray-200">
+                    <TableHead className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                      Id
+                    </TableHead>
+                    <TableHead className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                      Nombre del Ámbito
+                    </TableHead>
+                    <TableHead className="px-4 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                      Acciones
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {currentAmbitos.map((ambito) => (
+                    <TableRow
+                      key={ambito.id}
+                      className="hover:bg-gray-100 transition-colors"
+                    >
+                      <TableCell className="px-4 py-3 whitespace-nowrap">
+                        {ambito.id}
+                      </TableCell>
+                      <TableCell className="px-4 py-3 whitespace-nowrap">
+                        {ambito.nombreAmbito}
+                      </TableCell>
+                      <TableCell className="px-4 py-3 whitespace-nowrap text-right">
+                        <Button
+                          onClick={() => handleEdit(ambito.id)}
+                          className="bg-amber-500 text-white hover:bg-amber-600 mr-2"
+                        >
+                          <Pencil className="w-5 h-5" />
+                        </Button>
+                        <Button
+                          onClick={() => handleDeleteClick(ambito.id)}
+                          className="bg-red-500 text-white hover:bg-red-600"
+                        >
+                          <Trash2 className="w-5 h-5" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+        <div className="py-4 px-4 sm:px-6 border-t border-gray-200">
+          <Pagination
+            currentPage={ambitosState.pagination.currentPage}
+            totalPages={ambitosState.pagination.totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </div>
+
+      {isModalOpen && (
+        <AmbitoModal
+          isOpen={isModalOpen}
+          ambito={selectedAmbito}
+          onClose={handleCloseModal}
+          onSubmit={handleModalSubmit}
+        />
+      )}
+
+      {isDeleteModalOpen && (
+        <DeleteModal
+          isOpen={isDeleteModalOpen}
+          onClose={() => setIsDeleteModalOpen(false)}
+          onConfirm={handleDeleteConfirm}
+          itemName={selectedAmbito?.nombreAmbito || ""}
+        />
+      )}
+    </div>
+  );
+};
+
+export default AmbitoPage;


### PR DESCRIPTION
Esta pull request introduce una nueva funcionalidad para la gestión de "Ámbitos" en la aplicación. Incluye la adición de una nueva página, un modal y estructuras de datos de soporte para manejar la creación, edición y eliminación de "Ámbitos".

#### Cambios Realizados

* **Rutas e Importaciones de Componentes**:
  * Se agregó la importación y ruta de `AmbitoPage` en `src/App.tsx` para mostrar la lista de "Ámbitos".

* **Componente Modal para Ámbitos**:
  * Se creó el componente `AmbitoModal` en `src/components/modal/ambito-modal/AmbitoModal.tsx` para gestionar la creación y edición de "Ámbitos". Este modal utiliza `react-hook-form` y `zod` para la validación de formularios.

* **Modelos de Datos**:
  * Se agregó la interfaz `Ambito` en `src/model/ambito.ts` para definir la estructura de un "Ámbito".
  * Se añadió el tipo `AmbitoPaginatedResponse` en `src/model/ambitoPaginatedResponse.ts` para manejar respuestas paginadas de "Ámbitos".

* **Componente de Página de Ámbitos**:
  * Se creó el componente `AmbitoPage` en `src/pages/ambito-page/AmbitoPage.tsx` para mostrar, buscar, paginar y gestionar los "Ámbitos". Este componente incluye funcionalidad para abrir modales para agregar/editar y eliminar "Ámbitos".
